### PR TITLE
PHP 5.2 fix for load module files

### DIFF
--- a/src/core/Loader.php
+++ b/src/core/Loader.php
@@ -31,9 +31,11 @@ class Loader
 		// User Models, Views and Controllers
 
 		foreach ($this->folders as $folder) {
-			foreach (glob(THEME_ABSOLUTE_PATH . '/' . $folder . "/*.php") as $file) {
-                $this->loadFile($file);
-			}
+            foreach (glob(THEME_ABSOLUTE_PATH . '/' . $folder . "/*.php") as $file) {
+                if(!empty($file)):
+                    $this->loadFile($file);
+                endif;
+            }
 		}
 
         if(empty($this->app->post)){


### PR DESCRIPTION
Sergio, se tu quiser dar suporte ao PHP 5.2, aceita esse commit. É o unico erro que tá rolando quando usado servidores com a versão 5.2 do PHP (sim, ainda tenho clientes que utilizam essa versão).
